### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Implemented [Clean](https://dadata.ru/api/clean/) and [Suggest](https://dadata.r
 
 ## Installation
 
-`go get github.com/ekomobile/dadata`
+`go get github.com/ekomobile/dadata/v2`
 
 ## Usage
 ```go


### PR DESCRIPTION
Current Installation section contains command `go get github.com/ekomobile/dadata`. If you run it, the first version of package will be installed.

Correct command must be `go get github.com/ekomobile/dadata/v2`

Closes: #3 