### PR TITLE
feat: added missed fields in Phone model

### DIFF
--- a/api/model/model.go
+++ b/api/model/model.go
@@ -206,7 +206,9 @@ type (
 		Number              string `json:"number"`       // Локальный номер телефона
 		Extension           string `json:"extension"`    // Добавочный номер
 		Provider            string `json:"provider"`     // Оператор связи
+		Country		    string `json:"country"`      // Страна
 		Region              string `json:"region"`       // Регион
+		City                string `json:"city"`         // Город
 		Timezone            string `json:"timezone"`     // Часовой пояс
 		QualityCodeConflict int    `json:"qc_conflict"`  // Признак конфликта телефона с адресом
 		QualityCode         int    `json:"qc"`           // Код качества

--- a/api/model/model.go
+++ b/api/model/model.go
@@ -206,9 +206,9 @@ type (
 		Number              string `json:"number"`       // Локальный номер телефона
 		Extension           string `json:"extension"`    // Добавочный номер
 		Provider            string `json:"provider"`     // Оператор связи
-		Country		    string `json:"country"`      // Страна
+		Country             string `json:"country"`      // Страна
 		Region              string `json:"region"`       // Регион
-		City                string `json:"city"`         // Город
+		City                string `json:"city"`         // Город (только для стационарных телефонов)
 		Timezone            string `json:"timezone"`     // Часовой пояс
 		QualityCodeConflict int    `json:"qc_conflict"`  // Признак конфликта телефона с адресом
 		QualityCode         int    `json:"qc"`           // Код качества

--- a/api/model/model_test.go
+++ b/api/model/model_test.go
@@ -40,3 +40,51 @@ func TestParty(t *testing.T) {
 	assert.Equal(t, PartyFounderTypeLegal, model.Founders[0].Type)
 	assert.Equal(t, PartySMBCategorySmall, model.Documents.Smb.Category)
 }
+
+func TestPhone1(t *testing.T) {
+	dataReader, err := os.Open("test/phone1.json")
+	if err != nil {
+		t.Error(err)
+	}
+	defer dataReader.Close()
+
+	model := Phone{}
+
+	err = json.NewDecoder(dataReader).Decode(&model)
+	assert.NoError(t, err)
+	assert.Equal(t, "+375123456789", model.Source)
+	assert.Equal(t, "Беларусь", model.Country)
+	assert.Equal(t, "", model.City)
+}
+
+func TestPhone2(t *testing.T) {
+	dataReader, err := os.Open("test/phone2.json")
+	if err != nil {
+		t.Error(err)
+	}
+	defer dataReader.Close()
+
+	model := Phone{}
+
+	err = json.NewDecoder(dataReader).Decode(&model)
+	assert.NoError(t, err)
+	assert.Equal(t, "+79851234567", model.Source)
+	assert.Equal(t, "Россия", model.Country)
+	assert.Equal(t, "", model.City)
+}
+
+func TestPhone3(t *testing.T) {
+	dataReader, err := os.Open("test/phone3.json")
+	if err != nil {
+		t.Error(err)
+	}
+	defer dataReader.Close()
+
+	model := Phone{}
+
+	err = json.NewDecoder(dataReader).Decode(&model)
+	assert.NoError(t, err)
+	assert.Equal(t, "+123", model.Source)
+	assert.Equal(t, "", model.Country)
+	assert.Equal(t, "", model.City)
+}

--- a/api/model/test/phone1.json
+++ b/api/model/test/phone1.json
@@ -1,0 +1,16 @@
+{
+  "source": "+375123456789",
+  "type": "Стационарный",
+  "phone": "+375  123456789",
+  "country_code": "375",
+  "city_code": null,
+  "number": "123456789",
+  "extension": null,
+  "provider": null,
+  "country": "Беларусь",
+  "region": null,
+  "city": null,
+  "timezone": "UTC+3",
+  "qc_conflict": 0,
+  "qc": 7
+}

--- a/api/model/test/phone2.json
+++ b/api/model/test/phone2.json
@@ -1,0 +1,16 @@
+{
+  "source": "+79851234567",
+  "type": "Мобильный",
+  "phone": "+7 985 123-45-67",
+  "country_code": "7",
+  "city_code": "985",
+  "number": "1234567",
+  "extension": null,
+  "provider": "ПАО \"Мобильные ТелеСистемы\"",
+  "country": "Россия",
+  "region": "Москва и Московская область",
+  "city": null,
+  "timezone": "UTC+3",
+  "qc_conflict": 0,
+  "qc": 0
+}

--- a/api/model/test/phone3.json
+++ b/api/model/test/phone3.json
@@ -1,0 +1,16 @@
+{
+  "source": "+123",
+  "type": "Неизвестный",
+  "phone": null,
+  "country_code": null,
+  "city_code": null,
+  "number": null,
+  "extension": null,
+  "provider": null,
+  "country": null,
+  "region": null,
+  "city": null,
+  "timezone": null,
+  "qc_conflict": 0,
+  "qc": 1
+}


### PR DESCRIPTION
Added country, city for Phone model

Example:
```json
[
{
    "source": "раб 846)231.60.14 *139",
    "type": "Стационарный",
    "phone": "+7 846 231-60-14 доб. 139",
    "country_code": "7",
    "city_code": "846",
    "number": "2316014",
    "extension": "139",
    "provider": "ООО \"СИПАУТНЭТ\"",
    "country": "Россия",
    "region": "Самарская область",
    "city": "Самара",
    "timezone": "UTC+4",
    "qc_conflict": 0,
    "qc": 0
}
]
```