### PR TITLE
Добавили параметр 'Type' в запрос подсказок юрлиц

### DIFF
--- a/api/suggest/model.go
+++ b/api/suggest/model.go
@@ -40,8 +40,9 @@ type (
 
 	// RequestParams Request struct
 	RequestParams struct {
-		Query         string                   `json:"query"` // user input for suggestion
-		Count         int                      `json:"count"` // ligmit for results
+		Type          *PartyType               `json:"type,omitempty"` // party type for the suggestion (user input)
+		Query         string                   `json:"query"`          // user input for suggestion
+		Count         int                      `json:"count"`          // ligmit for results
 		Locations     []*RequestParamsLocation `json:"locations"`
 		RestrictValue bool                     `json:"restrict_value"` // don't show restricts (region) on results
 

--- a/dadata_test.go
+++ b/dadata_test.go
@@ -73,6 +73,34 @@ func (s *ApiSuggestIntegrationTest) TestParty() {
 	s.NotEmpty(res)
 }
 
+func (s *ApiSuggestIntegrationTest) TestPartyWithTypePositive() {
+	api := NewSuggestApi()
+
+	// positive: there are some legal entities "сбербанк"
+	legalParty := suggest.PartyTypeLegal
+	res, err := api.Party(context.Background(), &suggest.RequestParams{
+		Query: "сбербанк",
+		Type:  &legalParty,
+	})
+
+	s.NoError(err)
+	s.NotEmpty(res)
+}
+
+func (s *ApiSuggestIntegrationTest) TestPartyWithTypeMegative() {
+	api := NewSuggestApi()
+
+	// there are no one individual entrepreneur "сбербанк"
+	individualParty := suggest.PartyTypeIndividual
+	res, err := api.Party(context.Background(), &suggest.RequestParams{
+		Query: "сбербанк",
+		Type:  &individualParty,
+	})
+
+	s.NoError(err)
+	s.Empty(res)
+}
+
 func (s *ApiSuggestIntegrationTest) TestPartyById() {
 	api := NewSuggestApi()
 


### PR DESCRIPTION
АПИ подсказок для юрлиц поддерживает параметр type
Использовал для него уже имеющийся тип PartyType
Добавил тест