### PR TITLE
feat: suggest RequestPrams Language field added

### DIFF
--- a/api/suggest/model.go
+++ b/api/suggest/model.go
@@ -43,7 +43,7 @@ type (
 		Type          *PartyType               `json:"type,omitempty"` // party type for the suggestion (user input)
 		Query         string                   `json:"query"`          // user input for suggestion
 		Count         int                      `json:"count"`          // ligmit for results
-		Language      *string                  `json:"language,omitempty"`
+		Language      string                   `json:"language,omitempty"`
 		Locations     []*RequestParamsLocation `json:"locations"`
 		RestrictValue bool                     `json:"restrict_value"` // don't show restricts (region) on results
 

--- a/api/suggest/model.go
+++ b/api/suggest/model.go
@@ -42,6 +42,7 @@ type (
 	RequestParams struct {
 		Query         string                   `json:"query"` // user input for suggestion
 		Count         int                      `json:"count"` // ligmit for results
+		Language      string                   `json:"language"`
 		Locations     []*RequestParamsLocation `json:"locations"`
 		RestrictValue bool                     `json:"restrict_value"` // don't show restricts (region) on results
 

--- a/dadata_test.go
+++ b/dadata_test.go
@@ -53,6 +53,34 @@ func (s *ApiSuggestIntegrationTest) TestAddress() {
 	s.NotEmpty(res)
 }
 
+func (s *ApiSuggestIntegrationTest) TestAddressWithLanguageParamRU() {
+	api := NewSuggestApi()
+
+	params := suggest.RequestParams{
+		Query:    "ул Свободы",
+		Language: "RU",
+	}
+
+	res, err := api.Address(context.Background(), &params)
+
+	s.NoError(err)
+	s.NotEmpty(res)
+}
+
+func (s *ApiSuggestIntegrationTest) TestAddressWithLanguageParamEN() {
+	api := NewSuggestApi()
+
+	params := suggest.RequestParams{
+		Query:    "ул Свободы",
+		Language: "EN",
+	}
+
+	res, err := api.Address(context.Background(), &params)
+
+	s.NoError(err)
+	s.NotEmpty(res)
+}
+
 func (s *ApiSuggestIntegrationTest) TestBank() {
 	api := NewSuggestApi()
 	params := suggest.RequestParams{


### PR DESCRIPTION
В "API: подсказки по адресам" (https://dadata.ru/api/suggest/address/) реализована поддержка параметра language, но в данном клиенте он отсутвтует.